### PR TITLE
Add LeftBoundedQueryMonitor

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,2 @@
 [MASTER]
-disable=fixme,logging-fstring-interpolation
+disable=fixme,logging-fstring-interpolation,too-many-arguments

--- a/src/models.py
+++ b/src/models.py
@@ -4,6 +4,7 @@ Some generic models used throughout the project
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from enum import Enum
 
 from duneapi.types import QueryParameter
 
@@ -34,3 +35,51 @@ class TimeWindow:
     def next(self) -> TimeWindow:
         """Returns a TimeWindow beginning from the end of self with same length"""
         return TimeWindow(start=self.end, length_hours=self.length)
+
+
+class TimeUnit(Enum):
+    """
+    Enum representing SQL interval time units
+    """
+
+    SECONDS = "seconds"
+    MINUTES = "minutes"
+    HOURS = "hours"
+    DAYS = "days"
+    WEEKS = "weeks"
+    MONTHS = "months"
+
+    @classmethod
+    def options(cls) -> list[str]:
+        """Returns a list of all available enum items"""
+        return [e.value for e in cls]
+
+
+class LeftBound:
+    """Left Bound for Query Monitor"""
+
+    def __init__(self, units: TimeUnit, offset: int):
+        self.units = units
+        self.offset = offset
+
+    def as_query_parameters(self) -> list[QueryParameter]:
+        """Returns DuneQueryParameters for object instance"""
+        return [
+            QueryParameter.enum_type(
+                name="TimeUnits", value=self.units.value, options=TimeUnit.options()
+            ),
+            QueryParameter.number_type(name="Offset", value=self.offset),
+        ]
+
+    @classmethod
+    def from_cfg(cls, cfg: dict[str, int]) -> LeftBound:
+        """Loads LeftBound based on dict containing keys units and offset"""
+        return cls(
+            units=TimeUnit(cfg["units"]),
+            offset=int(cfg["offset"]),
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, LeftBound):
+            return self.units == other.units and self.offset == other.offset
+        raise ValueError(f"Can't compare LeftBound with {type(other)}")

--- a/src/query_monitor/base.py
+++ b/src/query_monitor/base.py
@@ -81,3 +81,7 @@ class BaseQueryMonitor(ABC):
             )
         else:
             log.info(f"No {self.name} detected")
+
+
+class QueryMonitor(BaseQueryMonitor):
+    """This is essentially the base query monitor with all default methods"""

--- a/src/query_monitor/base.py
+++ b/src/query_monitor/base.py
@@ -23,11 +23,17 @@ class BaseQueryMonitor(ABC):
     """
 
     def __init__(
-        self, name: str, query_id: int, params: Optional[list[QueryParameter]] = None
+        self,
+        name: str,
+        query_id: int,
+        params: Optional[list[QueryParameter]] = None,
+        threshold: int = 0,
     ):
         self.query_id = query_id
         self.fixed_params = params if params else []
         self.name = name
+        # Threshold for alert worthy number of results.
+        self.threshold = threshold
 
     def result_url(self) -> str:
         """Returns a link to query results excluding fixed parameters"""
@@ -64,7 +70,7 @@ class BaseQueryMonitor(ABC):
         """
         log.info(f'Refreshing "{self.name}" query {self.query_id}')
         results = self.refresh(dune)
-        if results:
+        if len(results) > self.threshold:
             log.error(self.alert_message(len(results)))
             slack_client.chat_postMessage(
                 channel=alert_channel,

--- a/src/query_monitor/factory.py
+++ b/src/query_monitor/factory.py
@@ -1,0 +1,34 @@
+"""
+Factory method to load QueryMonitor object from yaml configuration files
+"""
+from __future__ import annotations
+
+import yaml
+from duneapi.types import QueryParameter
+
+from src.models import TimeWindow, LeftBound
+from src.query_monitor.base import BaseQueryMonitor, QueryMonitor
+from src.query_monitor.left_bounded import LeftBoundedQueryMonitor
+from src.query_monitor.windowed import WindowedQueryMonitor
+
+
+def load_from_config(config_yaml: str) -> BaseQueryMonitor:
+    """Loads a QueryMonitor object from yaml configuration file"""
+    with open(config_yaml, "r", encoding="utf-8") as yaml_file:
+        cfg = yaml.load(yaml_file, yaml.Loader)
+
+    name, query_id = cfg["name"], cfg["id"]
+    threshold = cfg.get("threshold", 0)
+    params = [
+        QueryParameter.from_dict(param_cfg) for param_cfg in cfg.get("parameters", [])
+    ]
+    if "window" in cfg:
+        # Windowed Query
+        window = TimeWindow.from_cfg(cfg["window"])
+        return WindowedQueryMonitor(name, query_id, window, params, threshold)
+    if "left_bound" in cfg:
+        # Left Bounded Query
+        left_bound = LeftBound.from_cfg(cfg["left_bound"])
+        return LeftBoundedQueryMonitor(name, query_id, left_bound, params, threshold)
+
+    return QueryMonitor(name, query_id, params, threshold)

--- a/src/query_monitor/implementations.py
+++ b/src/query_monitor/implementations.py
@@ -26,14 +26,15 @@ def load_from_config(config_yaml: str) -> BaseQueryMonitor:
         cfg = yaml.load(yaml_file, yaml.Loader)
 
     name, query_id = cfg["name"], cfg["id"]
+    threshold = cfg.get("threshold", 0)
     params = [
         QueryParameter.from_dict(param_cfg) for param_cfg in cfg.get("parameters", [])
     ]
     try:
         window = TimeWindow.from_cfg(cfg["window"])
-        return WindowedQueryMonitor(name, query_id, window, params)
+        return WindowedQueryMonitor(name, query_id, window, params, threshold)
     except KeyError:
-        return QueryMonitor(name, query_id, params)
+        return QueryMonitor(name, query_id, params, threshold)
 
 
 class QueryMonitor(BaseQueryMonitor):
@@ -48,16 +49,19 @@ class WindowedQueryMonitor(BaseQueryMonitor):
 
     window: TimeWindow
 
+    # pylint:disable=too-many-arguments
     def __init__(
         self,
         name: str,
         query_id: int,
         window: TimeWindow,
         params: Optional[list[QueryParameter]] = None,
+        threshold: int = 0,
     ):
-        super().__init__(name, query_id, params)
+        super().__init__(name, query_id, params, threshold)
         self._set_window(window)
 
+    # pylint:enable=too-many-arguments
     def parameters(self) -> list[QueryParameter]:
         """Similar to the base model, but with window parameters appended"""
         return self.fixed_params + self.window.as_query_parameters()

--- a/src/query_monitor/left_bounded.py
+++ b/src/query_monitor/left_bounded.py
@@ -1,0 +1,39 @@
+"""Implementation of BaseQueryMonitor for queries beginning from StartTime"""
+import urllib.parse
+from typing import Optional
+
+from duneapi.types import QueryParameter
+
+from src.models import LeftBound
+from src.query_monitor.base import BaseQueryMonitor
+
+
+class LeftBoundedQueryMonitor(BaseQueryMonitor):
+    """
+    All queries here, must have `StartTime` as parameter.
+    This is set by an instance's left_bound attribute.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        query_id: int,
+        left_bound: LeftBound,
+        params: Optional[list[QueryParameter]] = None,
+        threshold: int = 0,
+    ):
+        super().__init__(name, query_id, params, threshold)
+        self.left_bound = left_bound
+
+    def parameters(self) -> list[QueryParameter]:
+        """Similar to the base model, but with left bound parameter appended"""
+        return self.fixed_params + self.left_bound.as_query_parameters()
+
+    def result_url(self) -> str:
+        """Returns a link to the query"""
+        base = super().result_url()
+        # Include variable parameters in the URL so they are set
+        query = "&".join(
+            [f"{p.key}={p.value}" for p in self.left_bound.as_query_parameters()]
+        )
+        return "?".join([base, urllib.parse.quote_plus(query, safe="=&?")])

--- a/src/query_monitor/windowed.py
+++ b/src/query_monitor/windowed.py
@@ -1,14 +1,11 @@
 """
-All implementations of the base QueryMonitor class
+Implementation of BaseQueryMonitor for "windowed" queries having StartTime and EndTime
 """
-from __future__ import annotations
-
 import logging.config
 import urllib.parse
 from datetime import datetime, timedelta
 from typing import Optional
 
-import yaml
 from duneapi.api import DuneAPI
 from duneapi.types import QueryParameter
 from slack.web.client import WebClient
@@ -18,27 +15,6 @@ from src.query_monitor.base import BaseQueryMonitor
 
 log = logging.getLogger(__name__)
 logging.config.fileConfig(fname="logging.conf", disable_existing_loggers=False)
-
-
-def load_from_config(config_yaml: str) -> BaseQueryMonitor:
-    """Loads a QueryMonitor object from yaml configuration file"""
-    with open(config_yaml, "r", encoding="utf-8") as yaml_file:
-        cfg = yaml.load(yaml_file, yaml.Loader)
-
-    name, query_id = cfg["name"], cfg["id"]
-    threshold = cfg.get("threshold", 0)
-    params = [
-        QueryParameter.from_dict(param_cfg) for param_cfg in cfg.get("parameters", [])
-    ]
-    try:
-        window = TimeWindow.from_cfg(cfg["window"])
-        return WindowedQueryMonitor(name, query_id, window, params, threshold)
-    except KeyError:
-        return QueryMonitor(name, query_id, params, threshold)
-
-
-class QueryMonitor(BaseQueryMonitor):
-    """This is essentially the base query monitor with all default methods"""
 
 
 class WindowedQueryMonitor(BaseQueryMonitor):

--- a/src/query_monitor/windowed.py
+++ b/src/query_monitor/windowed.py
@@ -25,7 +25,6 @@ class WindowedQueryMonitor(BaseQueryMonitor):
 
     window: TimeWindow
 
-    # pylint:disable=too-many-arguments
     def __init__(
         self,
         name: str,
@@ -37,7 +36,6 @@ class WindowedQueryMonitor(BaseQueryMonitor):
         super().__init__(name, query_id, params, threshold)
         self._set_window(window)
 
-    # pylint:enable=too-many-arguments
     def parameters(self) -> list[QueryParameter]:
         """Similar to the base model, but with window parameters appended"""
         return self.fixed_params + self.window.as_query_parameters()

--- a/src/slackbot.py
+++ b/src/slackbot.py
@@ -10,7 +10,7 @@ import dotenv
 from duneapi.api import DuneAPI
 from slack.web.client import WebClient
 
-from src.query_monitor.implementations import load_from_config
+from src.query_monitor.factory import load_from_config
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser("Missing Tokens")

--- a/tests/data/left-bounded.yaml
+++ b/tests/data/left-bounded.yaml
@@ -1,0 +1,5 @@
+name: Left Bounded Test
+id: 1
+left_bound:
+  units: hours
+  offset: 1

--- a/tests/test_implementations.py
+++ b/tests/test_implementations.py
@@ -4,11 +4,10 @@ import unittest
 from duneapi.types import QueryParameter
 
 from src.models import TimeWindow
-from src.query_monitor.implementations import (
-    load_from_config,
-    QueryMonitor,
-    WindowedQueryMonitor,
-)
+from src.query_monitor.base import QueryMonitor
+from src.query_monitor.factory import load_from_config
+from src.query_monitor.windowed import WindowedQueryMonitor
+from src.query_monitor.left_bounded import LeftBoundedQueryMonitor
 
 
 class TestQueryMonitor(unittest.TestCase):
@@ -58,7 +57,7 @@ class TestQueryMonitor(unittest.TestCase):
         )
 
 
-class TestLoadConfig(unittest.TestCase):
+class TestFactory(unittest.TestCase):
     def test_load_from_config(self):
         no_params_monitor = load_from_config("./tests/data/no-params.yaml")
         self.assertTrue(isinstance(no_params_monitor, QueryMonitor))
@@ -70,6 +69,9 @@ class TestLoadConfig(unittest.TestCase):
 
         windowed_monitor = load_from_config("./tests/data/windowed-query.yaml")
         self.assertTrue(isinstance(windowed_monitor, WindowedQueryMonitor))
+
+        left_bounded_monitor = load_from_config("./tests/data/left-bounded.yaml")
+        self.assertTrue(isinstance(left_bounded_monitor, LeftBoundedQueryMonitor))
 
 
 if __name__ == "__main__":

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 
 from duneapi.types import QueryParameter
 
-from src.models import TimeWindow
+from src.models import TimeWindow, LeftBound, TimeUnit
 
 
 class TestTimeWindow(unittest.TestCase):
@@ -46,6 +46,47 @@ class TestTimeWindow(unittest.TestCase):
                 QueryParameter.date_type(
                     name="EndTime", value=self.start + timedelta(hours=window.length)
                 ),
+            ],
+        )
+
+
+class TestLeftBound(unittest.TestCase):
+    def setUp(self) -> None:
+        self.left_bound = LeftBound(TimeUnit("minutes"), 1)
+
+    def test_constructor(self):
+        self.assertEqual(self.left_bound.units, TimeUnit.MINUTES)
+        self.assertEqual(self.left_bound.offset, 1)
+
+    def test_from_cfg(self):
+        print(self.left_bound.__dict__)
+        from_cfg = LeftBound.from_cfg(
+            {
+                "offset": 1,
+                "units": TimeUnit.MINUTES,
+            }
+        )
+        print(from_cfg.__dict__)
+        self.assertEqual(
+            LeftBound.from_cfg(
+                {
+                    "offset": 1,
+                    "units": TimeUnit.MINUTES,
+                }
+            ),
+            self.left_bound,
+        )
+
+    def test_as_query_params(self):
+        self.assertEqual(
+            self.left_bound.as_query_parameters(),
+            [
+                QueryParameter.enum_type(
+                    name="TimeUnits",
+                    value=TimeUnit.MINUTES.value,
+                    options=TimeUnit.options(),
+                ),
+                QueryParameter.number_type(name="Offset", value=1),
             ],
         )
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -59,14 +59,12 @@ class TestLeftBound(unittest.TestCase):
         self.assertEqual(self.left_bound.offset, 1)
 
     def test_from_cfg(self):
-        print(self.left_bound.__dict__)
         from_cfg = LeftBound.from_cfg(
             {
                 "offset": 1,
                 "units": TimeUnit.MINUTES,
             }
         )
-        print(from_cfg.__dict__)
         self.assertEqual(
             LeftBound.from_cfg(
                 {


### PR DESCRIPTION
Closes #6 (see issue for description). 

Here we begin to have multiple implementations of `QueryMonitor` so we split them into their own files. Introducing `LeftBoundedQueryMonitor` and testing all its functionality.

The intended usecase is for queries with time limitations defined as `where time > now() - interval '{{Offset}} {{TimeUnits}}'`

Note that we also introduce a Factory class for loading arbitrary `QueryMonitor` types from config file.

# Test Plan 

New unit tests captured by CI.