### PR TITLE
[Automation] Date Type Monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ parameters:
 ```
 
 where `DUNE_QUERY_ID` is found in the url of your existing query.
-For example, the integer at the end of this url https://dune.com/queries/857522.
+Concretely, it is the integer at the end of this url https://dune.com/queries/857522.
 
-For more details on query parameter configuration, please visit
+For more examples on query parameter configuration, checkout our test examples [./tests/data](./tests/data/)
 
 With all the configuration in place, then you can run the alerter with
 

--- a/src/models.py
+++ b/src/models.py
@@ -33,11 +33,15 @@ class TimeWindow:
         return TimeWindow.for_day(date.today() - timedelta(days=1))
 
     @classmethod
-    def for_day(cls, day: date):
+    def for_day(cls, day: date) -> TimeWindow:
+        """
+        Constructs TimeWindow for given day
+        (i.e. 24 time window beginning at midnight on specified day)
+        """
         return cls(
             # this is datetime object from date
             start=datetime.combine(day, datetime.min.time()),
-            length_hours=24
+            length_hours=24,
         )
 
     def as_query_parameters(self) -> list[QueryParameter]:

--- a/tests/data/day-window.yaml
+++ b/tests/data/day-window.yaml
@@ -1,0 +1,3 @@
+name: Day Window Example
+id: 1
+window: yesterday

--- a/tests/test_implementations.py
+++ b/tests/test_implementations.py
@@ -70,6 +70,9 @@ class TestFactory(unittest.TestCase):
         windowed_monitor = load_from_config("./tests/data/windowed-query.yaml")
         self.assertTrue(isinstance(windowed_monitor, WindowedQueryMonitor))
 
+        day_window_monitor = load_from_config("./tests/data/day-window.yaml")
+        self.assertTrue(isinstance(day_window_monitor, WindowedQueryMonitor))
+
         left_bounded_monitor = load_from_config("./tests/data/left-bounded.yaml")
         self.assertTrue(isinstance(left_bounded_monitor, LeftBoundedQueryMonitor))
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -34,12 +34,11 @@ class TestTimeWindow(unittest.TestCase):
         yesterday = today - timedelta(days=1)
 
         self.assertEqual(window.start, datetime.combine(yesterday, datetime.min.time()))
+        # The above assertion is equivalent to
         # self.assertEqual(window.start.date(), yesterday)
         # self.assertEqual(datetime.strftime(window.start, "%H:%M:%S"), "00:00:00")
 
         self.assertEqual(window.end, datetime.combine(today, datetime.min.time()))
-        # self.assertEqual(window.end.date(), today)
-        # self.assertEqual(datetime.strftime(window.end, "%H:%M:%S"), "00:00:00")
 
     def test_from_cfg_error(self):
         with self.assertRaises(AssertionError):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -41,6 +41,13 @@ class TestTimeWindow(unittest.TestCase):
         # self.assertEqual(window.end.date(), today)
         # self.assertEqual(datetime.strftime(window.end, "%H:%M:%S"), "00:00:00")
 
+    def test_from_cfg_error(self):
+        with self.assertRaises(AssertionError):
+            TimeWindow.from_cfg("invalid input")
+
+        with self.assertRaises(KeyError):
+            TimeWindow.from_cfg({"bad_key": 1})
+
     def test_from_day(self):
         window = TimeWindow.for_day(self.start.date())
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,6 @@
-import datetime
 import unittest
 
-from datetime import timedelta
+from datetime import timedelta, datetime
 
 from duneapi.types import QueryParameter
 
@@ -10,7 +9,7 @@ from src.models import TimeWindow, LeftBound, TimeUnit
 
 class TestTimeWindow(unittest.TestCase):
     def setUp(self) -> None:
-        self.start = datetime.datetime(year=1985, month=3, day=10)
+        self.start = datetime(year=1985, month=3, day=10)
 
     def test_constructor(self):
         start = self.start
@@ -29,7 +28,27 @@ class TestTimeWindow(unittest.TestCase):
         )
         self.assertEqual(window.end - window.start, timedelta(hours=length))
         self.assertEqual(window.length, length)
-        # Not sure if it makes sense to text the actual start since now() will evaluate differently...
+
+        window = TimeWindow.from_cfg("yesterday")
+        today = datetime.today().date()
+        yesterday = today - timedelta(days=1)
+
+        self.assertEqual(window.start, datetime.combine(yesterday, datetime.min.time()))
+        # self.assertEqual(window.start.date(), yesterday)
+        # self.assertEqual(datetime.strftime(window.start, "%H:%M:%S"), "00:00:00")
+
+        self.assertEqual(window.end, datetime.combine(today, datetime.min.time()))
+        # self.assertEqual(window.end.date(), today)
+        # self.assertEqual(datetime.strftime(window.end, "%H:%M:%S"), "00:00:00")
+
+    def test_from_day(self):
+        window = TimeWindow.for_day(self.start.date())
+
+        self.assertEqual(window.start, self.start)
+        self.assertEqual(window.end, self.start + timedelta(days=1))
+        self.assertEqual(window.end, self.start + timedelta(hours=24))
+        self.assertEqual(datetime.strftime(window.start, "%H:%M:%S"), "00:00:00")
+        self.assertEqual(datetime.strftime(window.end, "%H:%M:%S"), "00:00:00")
 
     def test_next(self):
         window = TimeWindow(self.start)
@@ -59,12 +78,6 @@ class TestLeftBound(unittest.TestCase):
         self.assertEqual(self.left_bound.offset, 1)
 
     def test_from_cfg(self):
-        from_cfg = LeftBound.from_cfg(
-            {
-                "offset": 1,
-                "units": TimeUnit.MINUTES,
-            }
-        )
         self.assertEqual(
             LeftBound.from_cfg(
                 {


### PR DESCRIPTION
Leveraging the `WindowedQueryMonitor` we enable the possibility to define a TimeWindow for an entire day and make configuring a "yesterday" time window very easy. This will be the configuration type for our Unusual Solver Slippage query because its the easiest to run as a cronjob (i.e. once per day, it will reveal any alerts regarding slippage for the previous day).


# Test Plan

New unit tests introduced.