### PR TITLE
[Easy] Remove run_loop override for WindowedQueryMonitor

### DIFF
--- a/src/query_monitor/base.py
+++ b/src/query_monitor/base.py
@@ -68,7 +68,7 @@ class BaseQueryMonitor(ABC):
         """
         Standard run-loop refreshing query, fetching results and alerting if necessary.
         """
-        log.info(f'Refreshing "{self.name}" query {self.query_id}')
+        log.info(f'Refreshing "{self.name}" query {self.result_url()}')
         results = self.refresh(dune)
         if len(results) > self.threshold:
             log.error(self.alert_message(len(results)))

--- a/src/query_monitor/windowed.py
+++ b/src/query_monitor/windowed.py
@@ -6,9 +6,7 @@ import urllib.parse
 from datetime import datetime, timedelta
 from typing import Optional
 
-from duneapi.api import DuneAPI
 from duneapi.types import QueryParameter
-from slack.web.client import WebClient
 
 from src.models import TimeWindow
 from src.query_monitor.base import BaseQueryMonitor
@@ -55,19 +53,3 @@ class WindowedQueryMonitor(BaseQueryMonitor):
                 "window end time is beyond 2 hours in the past, some data may not yet be available"
             )
         self.window = window
-
-    def run_loop(
-        self, dune: DuneAPI, slack_client: WebClient, alert_channel: str
-    ) -> None:
-        """
-        Originally designed to run infinitely and shift the window after each successful run
-        If we go with a memory-free approach this will not be used.
-        However, it can be adjusted to use Dune as persistent storage as follows:
-            - Query can be loaded from dune by ID.
-            - query can then be updated with configuration parameters as new defaults
-                (i.e. make the defaults equal to the current run).
-            Then, on the next run, shift the time window from the last successful run.
-        """
-        super().run_loop(dune, slack_client, alert_channel)
-        # After a successful run loop, we update the window for the next
-        self._set_window(self.window.next())


### PR DESCRIPTION
The original intention of this was to update the window after every successful runloop. However, this was with the assumption that the query monitor would run in an infinte loop and update its own schedule. We have since made this a cronjob that creates a new instance on every run.

This greatly simplifies the internal logic since we can inherit the base runloop implemented in the abstract class.

It was realized during deployment because of the following log warning:

```
➜  $ kubectl logs dev-dfusion-query-monitor-unusual-slippage-cj-27651315-7w54t
2022-07-29 07:15:25,129 INFO src.query_monitor.base Refreshing "Unusual Slippage" query 645559
2022-07-29 07:16:25,333 ERROR src.query_monitor.base Unusual Slippage - detected 17 cases. Results available at https://dune.com/queries/645559?StartTime=2022-07-28+00%3A00%3A00&EndTime=2022-07-29+00%3A00%3A00
2022-07-29 07:16:25,644 WARNING src.query_monitor.windowed window end time is beyond 2 hours in the past, some data may not yet be available
```

Since we had been updating the window after the runloop (which then hits a warning regarding the end time not being 2 hours in the past).

## Test Plan

Existing CI.