### PR TITLE
[Hotfix] Bump Dune Version

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,4 @@
-duneapi==3.1.1
+duneapi==4.0.0
 slackclient==2.9.4
 PyYAML==6.0
 types-PyYAML==6.0.10


### PR DESCRIPTION
Mandatory dependency update due to breaking changes. Related PR is here:

https://github.com/bh2smith/duneapi/pull/60