### PR TITLE
Preemptive Refactor

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,2 @@
 [MASTER]
-disable=fixme,logging-fstring-interpolation,too-many-arguments
+disable=fixme,logging-fstring-interpolation,too-many-arguments,too-few-public-methods

--- a/src/slack_client.py
+++ b/src/slack_client.py
@@ -1,0 +1,34 @@
+"""
+Since channel is fixed at the beginning and nobody wants to see unfurled media
+(especially in an alert), this tiny class encapsulates a few things that would
+otherwise be unnecessarily repeated.
+"""
+import ssl
+
+import certifi
+from slack.web.client import WebClient
+
+
+class BasicSlackClient:
+    """
+    Basic Slack Client with message post functionality
+    constructed from an API token and channel
+    """
+
+    def __init__(self, token: str, channel: str) -> None:
+        self.client = WebClient(
+            token=token,
+            # https://stackoverflow.com/questions/59808346/python-3-slack-client-ssl-sslcertverificationerror
+            ssl=ssl.create_default_context(cafile=certifi.where()),
+        )
+        self.channel = channel
+
+    def post(self, message: str) -> None:
+        """Posts `message` to `self.channel` excluding link previews."""
+        self.client.chat_postMessage(
+            channel=self.channel,
+            text=message,
+            # Do not show link preview!
+            # https://api.slack.com/reference/messaging/link-unfurling
+            unfurl_media=False,
+        )

--- a/tests/test_implementations.py
+++ b/tests/test_implementations.py
@@ -45,13 +45,13 @@ class TestQueryMonitor(unittest.TestCase):
 
     def test_alert_message(self):
         self.assertEqual(
-            self.monitor.alert_message(1),
+            self.monitor.alert_message([{}]),
             f"{self.monitor.name} - detected 1 cases. "
             f"Results available at {self.monitor.result_url()}",
         )
 
         self.assertEqual(
-            self.windowed_monitor.alert_message(2),
+            self.windowed_monitor.alert_message([{}, {}]),
             f"{self.windowed_monitor.name} - detected 2 cases. "
             f"Results available at {self.windowed_monitor.result_url()}",
         )


### PR DESCRIPTION
In preparation for a new type of Query Monitor (Counter type) we had to generalize some parts of the code to avoid duplication in the next extension class. Specifically we move slack client and dune connection into the query monitor class so that run_loop can be split into two parts (for more reusable components). 

Unfortunately this mean we temporarily initialize the class with dummy versions of these classes only to set them after instantiation (this is a hack so that unit tests don't require env vars be set). 

The plan is to move into something more general (although I have to do some design sketch before). 

**NOTE** the main goal of this is to make #16 easier to read. These will be followed up with a more general refactor aimed at cleaning up the abstraction patterns and reducing redundancy.