### PR TITLE
Counter Query Monitor (Take 2)

### DIFF
--- a/src/query_monitor/base.py
+++ b/src/query_monitor/base.py
@@ -1,7 +1,7 @@
 """
 Abstract class containing Base/Default QueryMonitor attributes.
 """
-from abc import ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Optional
 
@@ -43,10 +43,13 @@ class QueryBase(ABC):
         Base implementation only has fixed parameters,
         extensions (like WindowedQueryMonitor) would append additional parameters to the fixed ones
         """
+        return self.query.params or []
 
     def result_url(self) -> str:
         """Returns a link to query results excluding fixed parameters"""
+        return f"https://dune.com/queries/{self.query_id}"
 
+    @abstractmethod
     def alert_message(self, results: list[DuneRecord]) -> Alert:
         """
         Default Alert message if not special implementation is provided.

--- a/src/query_monitor/counter.py
+++ b/src/query_monitor/counter.py
@@ -1,0 +1,40 @@
+"""QueryMonitor for Counters. Alert set to valuation"""
+
+from duneapi.types import DuneRecord
+
+from src.alert import Alert, AlertLevel
+from src.query_monitor.base import QueryBase, QueryData
+
+
+class CounterQueryMonitor(QueryBase):
+    """
+    All queries here, must return a single record specifying a column with numeric type.
+    """
+
+    def __init__(
+        self,
+        query: QueryData,
+        column: str,
+        alert_value: float = 0.0,
+    ):
+        super().__init__(query)
+        self.column = column
+        self.alert_value = alert_value
+
+    def _result_value(self, results: list[DuneRecord]) -> float:
+        assert len(results) == 1, f"Expected single record, got {results}"
+        return float(results[0][self.column])
+
+    def alert_message(self, results: list[DuneRecord]) -> Alert:
+        result_value = self._result_value(results)
+        if result_value > self.alert_value:
+            return Alert(
+                kind=AlertLevel.SLACK,
+                value=f"Query {self.name}: {self.column} exceeds {self.alert_value} "
+                f"with {self._result_value(results)} (cf. {self.result_url()})",
+            )
+        return Alert(
+            kind=AlertLevel.LOG,
+            value=f"value of {self.column} = {result_value} "
+            f"does not exceed {self.alert_value}",
+        )

--- a/src/query_monitor/factory.py
+++ b/src/query_monitor/factory.py
@@ -8,6 +8,7 @@ from duneapi.types import QueryParameter
 
 from src.models import TimeWindow, LeftBound
 from src.query_monitor.base import QueryBase, QueryData
+from src.query_monitor.counter import CounterQueryMonitor
 from src.query_monitor.left_bounded import LeftBoundedQueryMonitor
 from src.query_monitor.result_threshold import ResultThresholdQuery
 from src.query_monitor.windowed import WindowedQueryMonitor
@@ -36,5 +37,10 @@ def load_from_config(config_yaml: str) -> QueryBase:
         # Left Bounded Query
         left_bound = LeftBound.from_cfg(cfg["left_bound"])
         return LeftBoundedQueryMonitor(query, left_bound, threshold)
+
+    if "column" in cfg and "alert_value" in cfg:
+        # Counter Query
+        column, alert_value = cfg["column"], float(cfg["alert_value"])
+        return CounterQueryMonitor(query, column, alert_value)
 
     return ResultThresholdQuery(query, threshold)

--- a/src/query_monitor/result_threshold.py
+++ b/src/query_monitor/result_threshold.py
@@ -22,10 +22,6 @@ class ResultThresholdQuery(QueryBase):
         """
         return self.query.params or []
 
-    def result_url(self) -> str:
-        """Returns a link to query results excluding fixed parameters"""
-        return f"https://dune.com/queries/{self.query_id}"
-
     def alert_message(self, results: list[DuneRecord]) -> Alert:
         """
         Default Alert message if not special implementation is provided.

--- a/tests/data/counter.yaml
+++ b/tests/data/counter.yaml
@@ -1,0 +1,4 @@
+name: Counter Test
+id: 1
+column: eth_spent
+alert_value: 55


### PR DESCRIPTION
The Counter Query Monitor expects the results to have only a single row, one can specify a column of that row and a threshold for the value. 

Use Cases: 

1. Monitoring to see when an account balance falls below a certain value.
2. Be alerted when our trading volume exceeds 100B so we can tweet about it.

Not much different from #16 but now based on #17 instead, should demonstrate how it is now super easy to add a new type of query monitor.

I noticed here that I wasn't properly using abstract method decorators in the base class which only became apparent here. This could be moved into the base PR.


# Test Plan

New and existing tests.
