### PR TITLE
Handle Dune Response Errors

### DIFF
--- a/src/dune_client.py
+++ b/src/dune_client.py
@@ -25,6 +25,16 @@ logging.config.fileConfig(fname="logging.conf", disable_existing_loggers=False)
 BASE_URL = "https://api.dune.com/api/v1"
 
 
+class DuneError(Exception):
+    """Two possibilities I've seen so far
+    {'error': 'invalid API Key'}
+    {'error': 'Query not found'}
+    """
+
+    def __init__(self, data: dict[str, str], response_class: str):
+        super().__init__(f"Can't build {response_class} from {data}")
+
+
 class ExecutionState(Enum):
     """
     Enum for possible values of Query Execution
@@ -211,8 +221,12 @@ class DuneClient(DuneInterface):
             },
             headers={"x-dune-api-key": self.token},
         )
-        log.debug(f"execute response {raw_response.json()}")
-        return ExecutionResponse.from_dict(raw_response.json())
+        response_json = raw_response.json()
+        log.debug(f"execute response {response_json}")
+        try:
+            return ExecutionResponse.from_dict(response_json)
+        except KeyError as err:
+            raise DuneError(response_json, "ExecutionResponse") from err
 
     def get_status(self, job_id: str) -> ExecutionStatusResponse:
         """GET status from Dune API for `job_id` (aka `execution_id`)"""
@@ -220,8 +234,12 @@ class DuneClient(DuneInterface):
             url=f"{BASE_URL}/execution/{job_id}/status",
             headers={"x-dune-api-key": self.token},
         )
-        log.debug(f"get_status response {raw_response.json()}")
-        return ExecutionStatusResponse.from_dict(raw_response.json())
+        response_json = raw_response.json()
+        log.debug(f"get_status response {response_json}")
+        try:
+            return ExecutionStatusResponse.from_dict(response_json)
+        except KeyError as err:
+            raise DuneError(response_json, "ExecutionStatusResponse") from err
 
     def get_result(self, job_id: str) -> ResultsResponse:
         """GET results from Dune API for `job_id` (aka `execution_id`)"""
@@ -229,8 +247,12 @@ class DuneClient(DuneInterface):
             url=f"{BASE_URL}/execution/{job_id}/results",
             headers={"x-dune-api-key": self.token},
         )
-        log.debug(f"get_result response {raw_response.json()}")
-        return ResultsResponse.from_dict(raw_response.json())
+        response_json = raw_response.json()
+        log.debug(f"get_result response {response_json}")
+        try:
+            return ResultsResponse.from_dict(response_json)
+        except KeyError as err:
+            raise DuneError(response_json, "ResultsResponse") from err
 
     def refresh(self, query: QueryBase) -> list[DuneRecord]:
         """

--- a/src/dune_client.py
+++ b/src/dune_client.py
@@ -26,9 +26,11 @@ BASE_URL = "https://api.dune.com/api/v1"
 
 
 class DuneError(Exception):
-    """Two possibilities I've seen so far
+    """Possibilities seen so far
     {'error': 'invalid API Key'}
     {'error': 'Query not found'}
+    {'error': 'An internal error occured'}
+    {'error': 'The requested execution ID (ID: Wonky Job ID) is invalid.'}
     """
 
     def __init__(self, data: dict[str, str], response_class: str):

--- a/tests/e2e/test_dune_client.py
+++ b/tests/e2e/test_dune_client.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import time
 import unittest
@@ -9,16 +10,20 @@ from src.dune_client import (
     ExecutionResponse,
     ExecutionStatusResponse,
     ExecutionState,
+    DuneError,
 )
 from src.query_monitor.factory import load_from_config
 
 
-class MyTestCase(unittest.TestCase):
-    def test_execute(self):
+class TestDuneClient(unittest.TestCase):
+    def setUp(self) -> None:
+        self.query = load_from_config("./tests/data/v2-test-data.yaml")
         dotenv.load_dotenv()
-        dune = DuneClient(api_key=os.environ["DUNE_API_KEY"])
-        query = load_from_config("./tests/data/v2-test-data.yaml")
-        execution_response = dune.execute(query)
+        self.valid_api_key = os.environ["DUNE_API_KEY"]
+
+    def test_endpoints(self):
+        dune = DuneClient(self.valid_api_key)
+        execution_response = dune.execute(self.query)
         self.assertIsInstance(execution_response, ExecutionResponse)
         job_id = execution_response.execution_id
         status = dune.get_status(job_id)
@@ -27,6 +32,63 @@ class MyTestCase(unittest.TestCase):
             time.sleep(1)
         results = dune.get_result(job_id).result.rows
         self.assertGreater(len(results), 0)
+
+    def test_invalid_api_key_error(self):
+        dune = DuneClient(api_key="Invalid Key")
+        with self.assertRaises(DuneError) as err:
+            dune.execute(self.query)
+        self.assertEqual(
+            str(err.exception),
+            "Can't build ExecutionResponse from {'error': 'invalid API Key'}",
+        )
+        with self.assertRaises(DuneError) as err:
+            dune.get_status("wonky job_id")
+        self.assertEqual(
+            str(err.exception),
+            "Can't build ExecutionStatusResponse from {'error': 'invalid API Key'}",
+        )
+        with self.assertRaises(DuneError) as err:
+            dune.get_result("wonky job_id")
+        self.assertEqual(
+            str(err.exception),
+            "Can't build ResultsResponse from {'error': 'invalid API Key'}",
+        )
+
+    def test_query_not_found_error(self):
+        dune = DuneClient(self.valid_api_key)
+        query = copy.copy(self.query)
+        query.query.query_id = 99999999  # Invalid Query Id.
+
+        with self.assertRaises(DuneError) as err:
+            dune.execute(query)
+        self.assertEqual(
+            str(err.exception),
+            "Can't build ExecutionResponse from {'error': 'Query not found'}",
+        )
+
+    def test_internal_error(self):
+        dune = DuneClient(self.valid_api_key)
+        query = copy.copy(self.query)
+        # This query ID is too large!
+        query.query.query_id = 9999999999999
+
+        with self.assertRaises(DuneError) as err:
+            dune.execute(query)
+        self.assertEqual(
+            str(err.exception),
+            "Can't build ExecutionResponse from {'error': 'An internal error occured'}",
+        )
+
+    def test_invalid_job_id_error(self):
+        dune = DuneClient(self.valid_api_key)
+
+        with self.assertRaises(DuneError) as err:
+            dune.get_status("Wonky Job ID")
+        self.assertEqual(
+            str(err.exception),
+            "Can't build ExecutionStatusResponse from "
+            "{'error': 'The requested execution ID (ID: Wonky Job ID) is invalid.'}",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
By trial and error, I have uncovered 4 different response errors.

```
{'error': 'invalid API Key'}
{'error': 'Query not found'}
{'error': 'An internal error occured'}
{'error': 'The requested execution ID (ID: Wonky Job ID) is invalid.'}
```

We implement error handlers on each of the API endpoints and test that they are returned when expected.

Soon Dune will document these responses and we can capture more, but I think this is pretty good for now.


Closes #21

Test Plan:

New e2e tests.