### PR TITLE
use library for date parsing

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,6 +1,8 @@
 duneapi==4.0.0
 slackclient==2.9.4
 PyYAML==6.0
+types-python-dateutil==2.8.19
 types-PyYAML==6.0.10
+python-dateutil==2.8.2
 python-dotenv==0.20.0
 certifi==2022.6.15

--- a/src/dune_client.py
+++ b/src/dune_client.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Union, Optional, Any
 
+from dateutil.parser import parse
 import requests
 from duneapi.api import DuneAPI
 from duneapi.types import DuneRecord
@@ -73,28 +74,9 @@ class TimeData:
     execution_started_at: datetime
     execution_ended_at: Optional[datetime]
 
-    @staticmethod
-    def parse(timestamp: str) -> datetime:
-        """
-        Sample Input:
-        '2022-08-29T06:33:24.913138Z' (standard expected format)
-        '2022-08-29T06:33:24.916543331Z' (has more than 6 digit milliseconds)
-        '1970-01-01T00:00:00Z' (special case emitted by Dune API).
-        """
-        # Remove the Z from end of timestamp
-        timestamp = timestamp[:-1]
-        # Milliseconds can not exceed 6 digits.
-        timestamp = timestamp[:26]
-        try:
-            return datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%f")
-        except ValueError:
-            # This case is specifically for input "1970-01-01T00:00:00Z"
-            return datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S")
-
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TimeData:
         """Constructor from dictionary. See unit test for sample input."""
-        parse = cls.parse
         end = data.get("execution_ended_at", None)
         return cls(
             submitted_at=parse(data["submitted_at"]),

--- a/tests/unit/test_dune_response_parsing.py
+++ b/tests/unit/test_dune_response_parsing.py
@@ -1,6 +1,8 @@
 import unittest
 from datetime import datetime
 
+from dateutil.tz import tzutc
+
 from src.dune_client import (
     ExecutionResponse,
     ExecutionStatusResponse,
@@ -62,19 +64,23 @@ class MyTestCase(unittest.TestCase):
 
     def test_parse_time_data(self):
         expected_with_end = TimeData(
-            submitted_at=datetime(2022, 8, 29, 6, 33, 24, 913138),
-            expires_at=datetime(2024, 8, 28, 6, 36, 41, 588470),
-            execution_started_at=datetime(2022, 8, 29, 6, 33, 24, 916543),
-            execution_ended_at=datetime(2022, 8, 29, 6, 36, 41, 588467),
+            submitted_at=datetime(2022, 8, 29, 6, 33, 24, 913138, tzinfo=tzutc()),
+            expires_at=datetime(2024, 8, 28, 6, 36, 41, 588470, tzinfo=tzutc()),
+            execution_started_at=datetime(
+                2022, 8, 29, 6, 33, 24, 916543, tzinfo=tzutc()
+            ),
+            execution_ended_at=datetime(2022, 8, 29, 6, 36, 41, 588467, tzinfo=tzutc()),
         )
         self.assertEqual(
             expected_with_end, TimeData.from_dict(self.results_response_data)
         )
 
         expected_without_end = TimeData(
-            submitted_at=datetime(2022, 8, 29, 6, 33, 24, 913138),
-            expires_at=datetime(1970, 1, 1, 0, 0),
-            execution_started_at=datetime(2022, 8, 29, 6, 33, 24, 916543),
+            submitted_at=datetime(2022, 8, 29, 6, 33, 24, 913138, tzinfo=tzutc()),
+            expires_at=datetime(1970, 1, 1, 0, 0, tzinfo=tzutc()),
+            execution_started_at=datetime(
+                2022, 8, 29, 6, 33, 24, 916543, tzinfo=tzutc()
+            ),
             execution_ended_at=None,
         )
         self.assertEqual(


### PR DESCRIPTION
Closes #23 

Using an existing library instead of manually manipulating date strings.


# Test Plan

Existing tests (specifically for `TimeData` parsing).