### PR TITLE
[BUG] Parameters Being Ignored

### DIFF
--- a/logging.conf
+++ b/logging.conf
@@ -1,5 +1,5 @@
 [loggers]
-keys=root,src.query_monitor
+keys=root,src
 
 [handlers]
 keys=consoleHandler
@@ -8,13 +8,13 @@ keys=consoleHandler
 keys=sampleFormatter
 
 [logger_root]
-level=DEBUG
+level=INFO
 handlers=consoleHandler
 propagate=0
 
-[logger_src.query_monitor]
-level=INFO
-qualname=src.fetch
+[logger_src]
+level=DEBUG
+qualname=src
 handlers=consoleHandler
 propagate=0
 

--- a/logging.conf
+++ b/logging.conf
@@ -8,7 +8,7 @@ keys=consoleHandler
 keys=sampleFormatter
 
 [logger_root]
-level=INFO
+level=DEBUG
 handlers=consoleHandler
 propagate=0
 

--- a/src/dune_client.py
+++ b/src/dune_client.py
@@ -218,7 +218,7 @@ class DuneClient(DuneInterface):
     def _post(self, url: str, params: Any) -> Any:
         log.debug(f"POST with input url={url}, params={params}")
         response = requests.post(
-            url=url, params=params, headers={"x-dune-api-key": self.token}
+            url=url, json=params, headers={"x-dune-api-key": self.token}
         )
         return self._handle_response(response)
 

--- a/src/dune_client.py
+++ b/src/dune_client.py
@@ -229,7 +229,8 @@ class DuneClient(DuneInterface):
             params={
                 "query_parameters": {
                     # TODO - change query parameters to make class._value_str() public.
-                    param.key: param.to_dict()["value"] for param in query.parameters()
+                    param.key: param.to_dict()["value"]
+                    for param in query.parameters()
                 }
             },
         )

--- a/src/dune_client.py
+++ b/src/dune_client.py
@@ -223,7 +223,8 @@ class DuneClient(DuneInterface):
             url=f"{BASE_URL}/query/{query.query_id}/execute",
             params={
                 "query_parameters": {
-                    param.key: param.value for param in query.parameters()
+                    # TODO - change query parameters to make class._value_str() public.
+                    param.key: param.to_dict()["value"] for param in query.parameters()
                 }
             },
         )

--- a/src/slackbot.py
+++ b/src/slackbot.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
         "--use-legacy-dune",
         type=bool,
         help="Indicate whether legacy duneapi client should be used.",
-        default=True,
+        default=False,
     )
     args = parser.parse_args()
     dotenv.load_dotenv()


### PR DESCRIPTION
We are observing that results being returned are ignoring the parameters being passed into the query. It is returning results with the default parameters. Unfortunately even with this change it appears the parameters are being ignored on Dune's end.

Logs before 

<details><summary>Logs Before</summary>
2022-09-02 07:37:55,023 DEBUG src.dune_client POST with input url=https://api.dune.com/api/v1/query/645559/execute, params={'query_parameters': {'MinAbsoluteSlippageTolerance': 100, 'RelativeSlippageTolerance': 0.3, 'SignificantSlippageValue': 1000, 'TxHash': '0x', 'StartTime': datetime.datetime(2022, 9, 1, 0, 0), 'EndTime': datetime.datetime(2022, 9, 2, 0, 0)}}


2022-09-02 07:39:38,253 DEBUG src.dune_client received response {'execution_id': '01GBYZWH01AST6KBKWQMADME32', 'query_id': 645559, 'state': 'QUERY_STATE_COMPLETED', 'submitted_at': '2022-09-02T11:37:55.456603Z', 'expires_at': '2024-09-01T11:39:35.024603Z', 'execution_started_at': '2022-09-02T11:37:55.483735Z', 'execution_ended_at': '2022-09-02T11:39:35.0246Z', 'result': {'rows': [{'batch_value': 5221499.25814526, 'block_time': '2022-06-26T13:50:50+00:00', 'relative_slippage': -0.072102008472873, 'solver_name': 'prod-Gnosis_1inch', 'tx_hash': '0xe61b6e365baccb84436e54bb4b501b1e7cb5256d0cb8cfb3386ec100275841f8', 'usd_value': -3764.8058375188957}, {'batch_value': 6162325.609893046, 'block_time': '2022-06-26T13:45:49+00:00', 'relative_slippage': 0.07735099275812471, 'solver_name': 'prod-Gnosis_ParaSwap', 'tx_hash': '0xa1e8cbdf036003064537bec765926cbaf023343e4bd6ecc26cd2b7f383f53dab', 'usd_value': 4766.620036240434}, {'batch_value': 26916.8348972397, 'block_time': '2022-06-21T04:34:12+00:00', 'relative_slippage': 0.5872444906167595, 'solver_name': 'prod-Otex', 'tx_hash': '0x1c980349657d64a7f0e670cf3dc91c1c665cb4851a93cbe8eeaad1067844c8ba', 'usd_value': 158.06762998244943}, {'batch_value': 18557.0267063278, 'block_time': '2022-06-21T12:58:07+00:00', 'relative_slippage': 0.9058199994225279, 'solver_name': 'prod-Otex', 'tx_hash': '0x80c08df815e2a440e2c4215ce4451a8f3a45132df0c97578b38f0d6dcc20fc4d', 'usd_value': 168.09325920409682}, {'batch_value': 21767.4204621324, 'block_time': '2022-06-24T00:48:06+00:00', 'relative_slippage': 0.9734593234698289, 'solver_name': 'prod-PLM', 'tx_hash': '0x0eebfe3f1f0149cb8a93579964b2eab1e9de899a004a2966680a08365addce5e', 'usd_value': 211.89698396750714}, {'batch_value': 7600.75973830635, 'block_time': '2022-06-26T04:51:44+00:00', 'relative_slippage': 2.222423203642035, 'solver_name': 'prod-Gnosis_ParaSwap', 'tx_hash': '0x41279890a73e77f160e78a2f07dfe3caf38c7676fae857f0d8701de8959be1c1', 'usd_value': 168.92104807720193}], 'metadata': {'column_names': ['block_time', 'solver_name', 'tx_hash', 'usd_value', 'batch_value', 'relative_slippage'], 'result_set_bytes': 1045, 'total_row_count': 6}}}
2022-09-02 07:39:38,254 INFO src.runner received results [{'batch_value': 5221499.25814526, 'block_time': '2022-06-26T13:50:50+00:00', 'relative_slippage': -0.072102008472873, 'solver_name': 'prod-Gnosis_1inch', 'tx_hash': '0xe61b6e365baccb84436e54bb4b501b1e7cb5256d0cb8cfb3386ec100275841f8', 'usd_value': -3764.8058375188957}, {'batch_value': 6162325.609893046, 'block_time': '2022-06-26T13:45:49+00:00', 'relative_slippage': 0.07735099275812471, 'solver_name': 'prod-Gnosis_ParaSwap', 'tx_hash': '0xa1e8cbdf036003064537bec765926cbaf023343e4bd6ecc26cd2b7f383f53dab', 'usd_value': 4766.620036240434}, {'batch_value': 26916.8348972397, 'block_time': '2022-06-21T04:34:12+00:00', 'relative_slippage': 0.5872444906167595, 'solver_name': 'prod-Otex', 'tx_hash': '0x1c980349657d64a7f0e670cf3dc91c1c665cb4851a93cbe8eeaad1067844c8ba', 'usd_value': 158.06762998244943}, {'batch_value': 18557.0267063278, 'block_time': '2022-06-21T12:58:07+00:00', 'relative_slippage': 0.9058199994225279, 'solver_name': 'prod-Otex', 'tx_hash': '0x80c08df815e2a440e2c4215ce4451a8f3a45132df0c97578b38f0d6dcc20fc4d', 'usd_value': 168.09325920409682}, {'batch_value': 21767.4204621324, 'block_time': '2022-06-24T00:48:06+00:00', 'relative_slippage': 0.9734593234698289, 'solver_name': 'prod-PLM', 'tx_hash': '0x0eebfe3f1f0149cb8a93579964b2eab1e9de899a004a2966680a08365addce5e', 'usd_value': 211.89698396750714}, {'batch_value': 7600.75973830635, 'block_time': '2022-06-26T04:51:44+00:00', 'relative_slippage': 2.222423203642035, 'solver_name': 'prod-Gnosis_ParaSwap', 'tx_hash': '0x41279890a73e77f160e78a2f07dfe3caf38c7676fae857f0d8701de8959be1c1', 'usd_value': 168.92104807720193}]
</details>


<details><summary>Logs After</summary>

2022-09-02 07:56:37,977 INFO src.runner Refreshing "Unusual Slippage" query https://dune.com/queries/645559?StartTime=2022-09-01+00%3A00%3A00&EndTime=2022-09-02+00%3A00%3A00
2022-09-02 07:56:37,977 DEBUG src.dune_client POST with input url=https://api.dune.com/api/v1/query/645559/execute, params={'query_parameters': {'MinAbsoluteSlippageTolerance': '100', 'RelativeSlippageTolerance': '0.3', 'SignificantSlippageValue': '1000', 'TxHash': '0x', 'StartTime': '2022-09-01 00:00:00', 'EndTime': '2022-09-02 00:00:00'}}

2022-09-02 07:58:10,497 DEBUG src.dune_client received response {'execution_id': '01GBZ0YSPG3TJA2F7DJH01PCT1', 'query_id': 645559, 'state': 'QUERY_STATE_COMPLETED', 'submitted_at': '2022-09-02T11:56:38.480527Z', 'expires_at': '2024-09-01T11:58:08.683069Z', 'execution_started_at': '2022-09-02T11:56:38.50815Z', 'execution_ended_at': '2022-09-02T11:58:08.683068Z', 'result': {'rows': [{'batch_value': 5221499.25814526, 'block_time': '2022-06-26T13:50:50+00:00', 'relative_slippage': -0.072102008472873, 'solver_name': 'prod-Gnosis_1inch', 'tx_hash': '0xe61b6e365baccb84436e54bb4b501b1e7cb5256d0cb8cfb3386ec100275841f8', 'usd_value': -3764.8058375188957}, {'batch_value': 6162325.609893046, 'block_time': '2022-06-26T13:45:49+00:00', 'relative_slippage': 0.07735099275812471, 'solver_name': 'prod-Gnosis_ParaSwap', 'tx_hash': '0xa1e8cbdf036003064537bec765926cbaf023343e4bd6ecc26cd2b7f383f53dab', 'usd_value': 4766.620036240434}, {'batch_value': 26916.8348972397, 'block_time': '2022-06-21T04:34:12+00:00', 'relative_slippage': 0.5872444906167595, 'solver_name': 'prod-Otex', 'tx_hash': '0x1c980349657d64a7f0e670cf3dc91c1c665cb4851a93cbe8eeaad1067844c8ba', 'usd_value': 158.06762998244943}, {'batch_value': 18557.0267063278, 'block_time': '2022-06-21T12:58:07+00:00', 'relative_slippage': 0.9058199994225279, 'solver_name': 'prod-Otex', 'tx_hash': '0x80c08df815e2a440e2c4215ce4451a8f3a45132df0c97578b38f0d6dcc20fc4d', 'usd_value': 168.09325920409682}, {'batch_value': 21767.4204621324, 'block_time': '2022-06-24T00:48:06+00:00', 'relative_slippage': 0.9734593234698289, 'solver_name': 'prod-PLM', 'tx_hash': '0x0eebfe3f1f0149cb8a93579964b2eab1e9de899a004a2966680a08365addce5e', 'usd_value': 211.89698396750714}, {'batch_value': 7600.75973830635, 'block_time': '2022-06-26T04:51:44+00:00', 'relative_slippage': 2.222423203642035, 'solver_name': 'prod-Gnosis_ParaSwap', 'tx_hash': '0x41279890a73e77f160e78a2f07dfe3caf38c7676fae857f0d8701de8959be1c1', 'usd_value': 168.92104807720193}], 'metadata': {'column_names': ['block_time', 'solver_name', 'tx_hash', 'usd_value', 'batch_value', 'relative_slippage'], 'result_set_bytes': 1045, 'total_row_count': 6}}}

2022-09-02 07:58:10,498 INFO src.runner received results [{'batch_value': 5221499.25814526, 'block_time': '2022-06-26T13:50:50+00:00', 'relative_slippage': -0.072102008472873, 'solver_name': 'prod-Gnosis_1inch', 'tx_hash': '0xe61b6e365baccb84436e54bb4b501b1e7cb5256d0cb8cfb3386ec100275841f8', 'usd_value': -3764.8058375188957}, {'batch_value': 6162325.609893046, 'block_time': '2022-06-26T13:45:49+00:00', 'relative_slippage': 0.07735099275812471, 'solver_name': 'prod-Gnosis_ParaSwap', 'tx_hash': '0xa1e8cbdf036003064537bec765926cbaf023343e4bd6ecc26cd2b7f383f53dab', 'usd_value': 4766.620036240434}, {'batch_value': 26916.8348972397, 'block_time': '2022-06-21T04:34:12+00:00', 'relative_slippage': 0.5872444906167595, 'solver_name': 'prod-Otex', 'tx_hash': '0x1c980349657d64a7f0e670cf3dc91c1c665cb4851a93cbe8eeaad1067844c8ba', 'usd_value': 158.06762998244943}, {'batch_value': 18557.0267063278, 'block_time': '2022-06-21T12:58:07+00:00', 'relative_slippage': 0.9058199994225279, 'solver_name': 'prod-Otex', 'tx_hash': '0x80c08df815e2a440e2c4215ce4451a8f3a45132df0c97578b38f0d6dcc20fc4d', 'usd_value': 168.09325920409682}, {'batch_value': 21767.4204621324, 'block_time': '2022-06-24T00:48:06+00:00', 'relative_slippage': 0.9734593234698289, 'solver_name': 'prod-PLM', 'tx_hash': '0x0eebfe3f1f0149cb8a93579964b2eab1e9de899a004a2966680a08365addce5e', 'usd_value': 211.89698396750714}, {'batch_value': 7600.75973830635, 'block_time': '2022-06-26T04:51:44+00:00', 'relative_slippage': 2.222423203642035, 'solver_name': 'prod-Gnosis_ParaSwap', 'tx_hash': '0x41279890a73e77f160e78a2f07dfe3caf38c7676fae857f0d8701de8959be1c1', 'usd_value': 168.92104807720193}]
2022-09-02 07:58:10,498 WARNING src.runner Unusual Slippage - detected 6 cases. Results available at https://dune.com/queries/645559?StartTime=2022-09-01+00%3A00%3A00&EndTime=2022-09-02+00%3A00%3A00
</details>


In both cases, we are getting results from June (the default parameters).

I will introduce a new e2e test here that demonstrates this much more clearly.