### PR TITLE
[HotFix] Make Legacy Dune Client Default

### DIFF
--- a/src/slackbot.py
+++ b/src/slackbot.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
         "--use-legacy-dune",
         type=bool,
         help="Indicate whether legacy duneapi client should be used.",
-        default=False,
+        default=True,
     )
     args = parser.parse_args()
     dotenv.load_dotenv()


### PR DESCRIPTION
It has become clear that the new Dune Client has a bug (cf #28 - outside of our control) and is not yet ready to be live in our kubernetes cluster. This is the easiest fix that doesn't require changing the pod configuration.

