### PR TITLE
Allow Specific Alert Channel per Query Monitor

### DIFF
--- a/src/slackbot.py
+++ b/src/slackbot.py
@@ -10,7 +10,7 @@ from dune_client.client import DuneClient
 from dune_client.interface import DuneInterface
 
 from src.query_monitor.base import QueryBase
-from src.query_monitor.factory import load_from_config
+from src.query_monitor.factory import load_config
 from src.runner import QueryRunner
 from src.slack_client import BasicSlackClient
 
@@ -36,10 +36,11 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     dotenv.load_dotenv()
+    config = load_config(args.query_config)
     run_slackbot(
-        query=load_from_config(args.query_config),
+        query=config.query,
         dune=DuneClient(os.environ["DUNE_API_KEY"]),
         slack_client=BasicSlackClient(
-            token=os.environ["SLACK_TOKEN"], channel=os.environ["SLACK_ALERT_CHANNEL"]
+            token=os.environ["SLACK_TOKEN"], channel=config.alert_channel
         ),
     )

--- a/tests/data/alert-channel.yaml
+++ b/tests/data/alert-channel.yaml
@@ -1,0 +1,5 @@
+name: Counter Test
+id: 1
+column: eth_spent
+alert_value: 55
+alert_channel: Specific Channel

--- a/tests/e2e/test_query_runner.py
+++ b/tests/e2e/test_query_runner.py
@@ -8,13 +8,14 @@ from dune_client.client import DuneClient
 from src.query_monitor.factory import load_config
 from src.runner import QueryRunner
 from src.slack_client import BasicSlackClient
+from tests.file import filepath
 
 
 class MyTestCase(unittest.TestCase):
     @patch.object(BasicSlackClient, "post")
     def test_query_runner(self, mocked_post):
         dotenv.load_dotenv()
-        query = load_config("./tests/data/v2-test-data.yaml").query
+        query = load_config(filepath("v2-test-data.yaml")).query
         dune = DuneClient(os.environ["DUNE_API_KEY"])
         slack_client = BasicSlackClient(token="Fake Token", channel="Fake Channel")
         query_runner = QueryRunner(query, dune, slack_client)

--- a/tests/e2e/test_query_runner.py
+++ b/tests/e2e/test_query_runner.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import dotenv
 from dune_client.client import DuneClient
 
-from src.query_monitor.factory import load_from_config
+from src.query_monitor.factory import load_config
 from src.runner import QueryRunner
 from src.slack_client import BasicSlackClient
 
@@ -14,7 +14,7 @@ class MyTestCase(unittest.TestCase):
     @patch.object(BasicSlackClient, "post")
     def test_query_runner(self, mocked_post):
         dotenv.load_dotenv()
-        query = load_from_config("./tests/data/v2-test-data.yaml")
+        query = load_config("./tests/data/v2-test-data.yaml").query
         dune = DuneClient(os.environ["DUNE_API_KEY"])
         slack_client = BasicSlackClient(token="Fake Token", channel="Fake Channel")
         query_runner = QueryRunner(query, dune, slack_client)

--- a/tests/file.py
+++ b/tests/file.py
@@ -1,0 +1,8 @@
+import os
+from pathlib import Path
+
+TEST_CONFIG_PATH = Path(__file__).parent / Path("data")
+
+
+def filepath(name: str) -> str:
+    return os.path.join(TEST_CONFIG_PATH, name)

--- a/tests/unit/test_implementations.py
+++ b/tests/unit/test_implementations.py
@@ -11,6 +11,7 @@ from src.query_monitor.factory import load_config
 from src.query_monitor.result_threshold import ResultThresholdQuery
 from src.query_monitor.windowed import WindowedQueryMonitor, TimeWindow
 from src.query_monitor.left_bounded import LeftBoundedQueryMonitor
+from tests.file import filepath
 
 
 class TestQueryMonitor(unittest.TestCase):
@@ -80,26 +81,26 @@ class TestQueryMonitor(unittest.TestCase):
 class TestFactory(unittest.TestCase):
     def test_load_from_config(self):
         os.environ["SLACK_ALERT_CHANNEL"] = "dummy channel"
-        no_params_monitor = load_config("./tests/data/no-params.yaml").query
+        no_params_monitor = load_config(filepath("no-params.yaml")).query
         self.assertTrue(isinstance(no_params_monitor, ResultThresholdQuery))
         self.assertEqual(no_params_monitor.parameters(), [])
 
-        with_params_monitor = load_config("./tests/data/with-params.yaml").query
+        with_params_monitor = load_config(filepath("with-params.yaml")).query
         self.assertGreater(len(with_params_monitor.parameters()), 0)
         self.assertTrue(isinstance(with_params_monitor, ResultThresholdQuery))
 
-        windowed_monitor = load_config("./tests/data/windowed-query.yaml").query
+        windowed_monitor = load_config(filepath("windowed-query.yaml")).query
         self.assertTrue(isinstance(windowed_monitor, WindowedQueryMonitor))
 
-        day_window_monitor = load_config("./tests/data/day-window.yaml").query
+        day_window_monitor = load_config(filepath("day-window.yaml")).query
         self.assertTrue(isinstance(day_window_monitor, WindowedQueryMonitor))
 
-        left_bounded_monitor = load_config("./tests/data/left-bounded.yaml").query
+        left_bounded_monitor = load_config(filepath("left-bounded.yaml")).query
         self.assertTrue(isinstance(left_bounded_monitor, LeftBoundedQueryMonitor))
 
     def test_load_config_error(self):
         with self.assertRaises(KeyError):
-            load_config("./tests/data/no-params.yaml")
+            load_config(filepath("no-params.yaml"))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_implementations.py
+++ b/tests/unit/test_implementations.py
@@ -6,7 +6,7 @@ from dune_client.types import QueryParameter
 
 from src.alert import Alert, AlertLevel
 from src.query_monitor.counter import CounterQueryMonitor
-from src.query_monitor.factory import load_from_config
+from src.query_monitor.factory import load_config
 from src.query_monitor.result_threshold import ResultThresholdQuery
 from src.query_monitor.windowed import WindowedQueryMonitor, TimeWindow
 from src.query_monitor.left_bounded import LeftBoundedQueryMonitor
@@ -78,21 +78,21 @@ class TestQueryMonitor(unittest.TestCase):
 
 class TestFactory(unittest.TestCase):
     def test_load_from_config(self):
-        no_params_monitor = load_from_config("./tests/data/no-params.yaml")
+        no_params_monitor = load_config("./tests/data/no-params.yaml").query
         self.assertTrue(isinstance(no_params_monitor, ResultThresholdQuery))
         self.assertEqual(no_params_monitor.parameters(), [])
 
-        with_params_monitor = load_from_config("./tests/data/with-params.yaml")
+        with_params_monitor = load_config("./tests/data/with-params.yaml").query
         self.assertGreater(len(with_params_monitor.parameters()), 0)
         self.assertTrue(isinstance(with_params_monitor, ResultThresholdQuery))
 
-        windowed_monitor = load_from_config("./tests/data/windowed-query.yaml")
+        windowed_monitor = load_config("./tests/data/windowed-query.yaml").query
         self.assertTrue(isinstance(windowed_monitor, WindowedQueryMonitor))
 
-        day_window_monitor = load_from_config("./tests/data/day-window.yaml")
+        day_window_monitor = load_config("./tests/data/day-window.yaml").query
         self.assertTrue(isinstance(day_window_monitor, WindowedQueryMonitor))
 
-        left_bounded_monitor = load_from_config("./tests/data/left-bounded.yaml")
+        left_bounded_monitor = load_config("./tests/data/left-bounded.yaml").query
         self.assertTrue(isinstance(left_bounded_monitor, LeftBoundedQueryMonitor))
 
 

--- a/tests/unit/test_implementations.py
+++ b/tests/unit/test_implementations.py
@@ -97,6 +97,7 @@ class TestFactory(unittest.TestCase):
 
         left_bounded_monitor = load_config(filepath("left-bounded.yaml")).query
         self.assertTrue(isinstance(left_bounded_monitor, LeftBoundedQueryMonitor))
+        del os.environ["SLACK_ALERT_CHANNEL"]
 
     def test_load_config_error(self):
         with self.assertRaises(KeyError):

--- a/tests/unit/test_implementations.py
+++ b/tests/unit/test_implementations.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import unittest
 
 from dune_client.query import Query
@@ -78,6 +79,7 @@ class TestQueryMonitor(unittest.TestCase):
 
 class TestFactory(unittest.TestCase):
     def test_load_from_config(self):
+        os.environ["SLACK_ALERT_CHANNEL"] = "dummy channel"
         no_params_monitor = load_config("./tests/data/no-params.yaml").query
         self.assertTrue(isinstance(no_params_monitor, ResultThresholdQuery))
         self.assertEqual(no_params_monitor.parameters(), [])
@@ -94,6 +96,10 @@ class TestFactory(unittest.TestCase):
 
         left_bounded_monitor = load_config("./tests/data/left-bounded.yaml").query
         self.assertTrue(isinstance(left_bounded_monitor, LeftBoundedQueryMonitor))
+
+    def test_load_config_error(self):
+        with self.assertRaises(KeyError):
+            load_config("./tests/data/no-params.yaml")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_load_config.py
+++ b/tests/unit/test_load_config.py
@@ -1,0 +1,26 @@
+import unittest
+import os
+from pathlib import Path
+
+from src.query_monitor.factory import load_config
+
+TEST_CONFIG_PATH = Path(__file__).parent.parent / Path("data")
+
+
+class TestConfigLoading(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fallback_alert_channel = "Default"
+        os.environ["SLACK_ALERT_CHANNEL"] = self.fallback_alert_channel
+
+    def test_default_config(self):
+
+        config = load_config(os.path.join(TEST_CONFIG_PATH, "counter.yaml"))
+        self.assertEqual(config.alert_channel, self.fallback_alert_channel)
+
+    def test_specified_channel(self):
+        config = load_config(os.path.join(TEST_CONFIG_PATH, "alert-channel.yaml"))
+        self.assertEqual(config.alert_channel, "Specific Channel")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_load_config.py
+++ b/tests/unit/test_load_config.py
@@ -1,10 +1,8 @@
-import unittest
 import os
-from pathlib import Path
+import unittest
 
 from src.query_monitor.factory import load_config
-
-TEST_CONFIG_PATH = Path(__file__).parent.parent / Path("data")
+from tests.file import filepath
 
 
 class TestConfigLoading(unittest.TestCase):
@@ -14,11 +12,11 @@ class TestConfigLoading(unittest.TestCase):
 
     def test_default_config(self):
 
-        config = load_config(os.path.join(TEST_CONFIG_PATH, "counter.yaml"))
+        config = load_config(filepath("counter.yaml"))
         self.assertEqual(config.alert_channel, self.fallback_alert_channel)
 
     def test_specified_channel(self):
-        config = load_config(os.path.join(TEST_CONFIG_PATH, "alert-channel.yaml"))
+        config = load_config(filepath("alert-channel.yaml"))
         self.assertEqual(config.alert_channel, "Specific Channel")
 
 


### PR DESCRIPTION
We will still hold on to a "fallback" universal slack channel (#alerts-dune), but now have the option to specific `alert_channel` in an individual query config.yaml.

Also took this opportunity to remove relative filepaths

## Test Plan

A couple of new unit tests introduced to validate the configuration file loading.
