### PR TITLE
Raise on slack post error and add debug logs.

### DIFF
--- a/src/query_monitor/factory.py
+++ b/src/query_monitor/factory.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
+import logging.config
 import yaml
 from dune_client.types import QueryParameter
 from dune_client.query import Query
@@ -15,6 +16,10 @@ from src.query_monitor.counter import CounterQueryMonitor
 from src.query_monitor.left_bounded import LeftBoundedQueryMonitor
 from src.query_monitor.result_threshold import ResultThresholdQuery
 from src.query_monitor.windowed import WindowedQueryMonitor
+
+
+log = logging.getLogger(__name__)
+logging.config.fileConfig(fname="logging.conf", disable_existing_loggers=False)
 
 
 @dataclass
@@ -31,7 +36,7 @@ def load_config(config_yaml: str) -> Config:
     """Loads a QueryMonitor object from yaml configuration file"""
     with open(config_yaml, "r", encoding="utf-8") as yaml_file:
         cfg = yaml.load(yaml_file, yaml.Loader)
-
+    log.debug(f"config {config_yaml} loaded as {cfg}")
     query = Query(
         name=cfg["name"],
         query_id=cfg["id"],
@@ -58,8 +63,10 @@ def load_config(config_yaml: str) -> Config:
     else:
         base_query = ResultThresholdQuery(query, threshold)
 
-    return Config(
+    config_obj = Config(
         query=base_query,
         # Use specified channel, or default to "global config"
         alert_channel=cfg.get("alert_channel", os.environ["SLACK_ALERT_CHANNEL"]),
     )
+    log.debug(f"config parsed as {config_obj}")
+    return config_obj

--- a/src/slack_client.py
+++ b/src/slack_client.py
@@ -4,14 +4,15 @@ Since channel is fixed at the beginning and nobody wants to see unfurled media
 otherwise be unnecessarily repeated.
 """
 import ssl
-
-import certifi
 import logging.config
+import certifi
+
 from slack.errors import SlackApiError
 from slack.web.client import WebClient
 
 log = logging.getLogger(__name__)
 logging.config.fileConfig(fname="logging.conf", disable_existing_loggers=False)
+
 
 class BasicSlackClient:
     """
@@ -32,11 +33,11 @@ class BasicSlackClient:
         log.info(f"posting to slack channel: {self.channel}")
         try:
             self.client.chat_postMessage(
-                    channel=self.channel,
-                    text=message,
-                    # Do not show link preview!
-                    # https://api.slack.com/reference/messaging/link-unfurling
-                    unfurl_media=False,
-                )
+                channel=self.channel,
+                text=message,
+                # Do not show link preview!
+                # https://api.slack.com/reference/messaging/link-unfurling
+                unfurl_media=False,
+            )
         except SlackApiError as err:
             raise RuntimeError(f"slack post failed with {err}") from err

--- a/src/slack_client.py
+++ b/src/slack_client.py
@@ -6,8 +6,12 @@ otherwise be unnecessarily repeated.
 import ssl
 
 import certifi
+import logging.config
+from slack.errors import SlackApiError
 from slack.web.client import WebClient
 
+log = logging.getLogger(__name__)
+logging.config.fileConfig(fname="logging.conf", disable_existing_loggers=False)
 
 class BasicSlackClient:
     """
@@ -25,10 +29,14 @@ class BasicSlackClient:
 
     def post(self, message: str) -> None:
         """Posts `message` to `self.channel` excluding link previews."""
-        self.client.chat_postMessage(
-            channel=self.channel,
-            text=message,
-            # Do not show link preview!
-            # https://api.slack.com/reference/messaging/link-unfurling
-            unfurl_media=False,
-        )
+        log.info(f"posting to slack channel: {self.channel}")
+        try:
+            self.client.chat_postMessage(
+                    channel=self.channel,
+                    text=message,
+                    # Do not show link preview!
+                    # https://api.slack.com/reference/messaging/link-unfurling
+                    unfurl_media=False,
+                )
+        except SlackApiError as err:
+            raise RuntimeError(f"slack post failed with {err}") from err


### PR DESCRIPTION
Seems there is an issue with slack client library that it doesn't properly raise an exception when message post fails:

https://github.com/slackapi/python-slack-sdk/issues/847

Thus, we have manually attempted to handle this exception. Furthermore, we add a few other debug logs to see the progress of the each run better (when necessary). 

Today the issue was that our alert was failing to post, but there was not pod or logs in the deployment that would indicate it hadn't succeeded.

This is not urgent because the alert bot has been added to the appropriate channel, but in the future it would be nice to know.