### PR TITLE
[V3] Add DuneSQL support for Left Bounded Monitors

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -67,6 +67,13 @@ class TimeUnit(Enum):
     DAYS = "days"
     WEEKS = "weeks"
     MONTHS = "months"
+    # Values to support V3 (DuneSQL)
+    SECOND = "second"
+    MINUTE = "minute"
+    HOUR = "hour"
+    DAY = "day"
+    WEEK = "week"
+    MONTH = "month"
 
     @classmethod
     def options(cls) -> list[str]:

--- a/src/models.py
+++ b/src/models.py
@@ -3,7 +3,7 @@ Some generic models used throughout the project
 """
 from __future__ import annotations
 
-from datetime import datetime, timedelta, date
+from datetime import datetime, timedelta, date, tzinfo
 from enum import Enum
 
 from dune_client.types import QueryParameter
@@ -29,8 +29,10 @@ class TimeWindow:
                 start=datetime.now() - timedelta(hours=cfg["offset"]),
                 length_hours=cfg["length"],
             )
-        assert cfg == "yesterday"
-        return TimeWindow.for_day(date.today() - timedelta(days=1))
+        assert cfg in ("yesterday", "last_hour")
+        if cfg == "yesterday":
+            return TimeWindow.for_day(date.today() - timedelta(days=1))
+        return TimeWindow(start=datetime.utcnow() - timedelta(hours=1), length_hours=1)
 
     @classmethod
     def for_day(cls, day: date) -> TimeWindow:
@@ -43,6 +45,7 @@ class TimeWindow:
             start=datetime.combine(day, datetime.min.time()),
             length_hours=24,
         )
+
 
     def as_query_parameters(self) -> list[QueryParameter]:
         """Dune query parameters defined by the start and end of the window"""

--- a/src/models.py
+++ b/src/models.py
@@ -46,7 +46,6 @@ class TimeWindow:
             length_hours=24,
         )
 
-
     def as_query_parameters(self) -> list[QueryParameter]:
         """Dune query parameters defined by the start and end of the window"""
         return [

--- a/src/models.py
+++ b/src/models.py
@@ -3,7 +3,7 @@ Some generic models used throughout the project
 """
 from __future__ import annotations
 
-from datetime import datetime, timedelta, date, tzinfo
+from datetime import datetime, timedelta, date
 from enum import Enum
 
 from dune_client.types import QueryParameter

--- a/tests/data/v3-last-hour.yaml
+++ b/tests/data/v3-last-hour.yaml
@@ -1,0 +1,3 @@
+name: Last Hour (Deterministic)
+id: 1944772
+window: last_hour

--- a/tests/data/v3-left-bounded.yaml
+++ b/tests/data/v3-left-bounded.yaml
@@ -1,0 +1,5 @@
+name: V3 Test Left Bounded
+id: 1944696
+left_bound:
+  units: hour
+  offset: 1

--- a/tests/e2e/test_query_runner.py
+++ b/tests/e2e/test_query_runner.py
@@ -36,6 +36,18 @@ class MyTestCase(unittest.TestCase):
             f"{query.name} - detected 1 cases. Results available at {query.result_url()}"
         )
 
+    @patch.object(BasicSlackClient, "post")
+    def test_v3_last_hour(self, mocked_post):
+        dotenv.load_dotenv()
+        query = load_config(filepath("v3-last-hour.yaml")).query
+        dune = DuneClient(os.environ["DUNE_API_KEY"])
+        slack_client = BasicSlackClient(token="Fake Token", channel="Fake Channel")
+        query_runner = QueryRunner(query, dune, slack_client)
+        query_runner.run_loop()
+        mocked_post.assert_called_with(
+            f"{query.name} - detected 1 cases. Results available at {query.result_url()}"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/e2e/test_query_runner.py
+++ b/tests/e2e/test_query_runner.py
@@ -24,6 +24,18 @@ class MyTestCase(unittest.TestCase):
             f"{query.name} - detected 1 cases. Results available at {query.result_url()}"
         )
 
+    @patch.object(BasicSlackClient, "post")
+    def test_v3_query(self, mocked_post):
+        dotenv.load_dotenv()
+        query = load_config(filepath("v3-left-bounded.yaml")).query
+        dune = DuneClient(os.environ["DUNE_API_KEY"])
+        slack_client = BasicSlackClient(token="Fake Token", channel="Fake Channel")
+        query_runner = QueryRunner(query, dune, slack_client)
+        query_runner.run_loop()
+        mocked_post.assert_called_with(
+            f"{query.name} - detected 1 cases. Results available at {query.result_url()}"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
DuneSQL time operations do not support plurals like `now() - interval '2 days'` but rather only singular equivalents like

```sql
now() - interval '2' day
```

This change is the least invasive way to add support for both.

We also take this opportunity to add `last_hour` support to Windowed Query Monitor. The difference between LeftBounded and Windowed Last Hour is that LeftBounded Queries are non-deterministic in the sense that they may return different results when executed later in time (since the Right end point -- in time -- is now()).