### PR TITLE
Configurable Ping Frequency

### DIFF
--- a/src/query_monitor/factory.py
+++ b/src/query_monitor/factory.py
@@ -29,6 +29,7 @@ class Config:
     """
 
     query: QueryBase
+    ping_frequency: int
     alert_channel: str
 
 
@@ -67,6 +68,8 @@ def load_config(config_yaml: str) -> Config:
         query=base_query,
         # Use specified channel, or default to "global config"
         alert_channel=cfg.get("alert_channel", os.environ["SLACK_ALERT_CHANNEL"]),
+        # This is 4x the DuneClient default of 5 seconds
+        ping_frequency=cfg.get("ping_frequency", 20),
     )
     log.debug(f"config parsed as {config_obj}")
     return config_obj

--- a/src/runner.py
+++ b/src/runner.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging.config
 
-from dune_client.interface import DuneInterface
+from dune_client.client import DuneClient
 
 from src.alert import AlertLevel
 from src.query_monitor.base import QueryBase
@@ -23,11 +23,16 @@ class QueryRunner:
     """
 
     def __init__(
-        self, query: QueryBase, dune: DuneInterface, slack_client: BasicSlackClient
+        self,
+        query: QueryBase,
+        dune: DuneClient,
+        slack_client: BasicSlackClient,
+        ping_frequency: int,
     ):
         self.query = query
         self.dune = dune
         self.slack_client = slack_client
+        self.ping_frequency = ping_frequency
 
     def run_loop(self) -> None:
         """
@@ -35,7 +40,7 @@ class QueryRunner:
         """
         query = self.query
         log.info(f'Refreshing "{query.name}" query {query.result_url()}')
-        results = self.dune.refresh(query.query)
+        results = self.dune.refresh(query.query, self.ping_frequency)
         alert = query.get_alert(results)
         if alert.level == AlertLevel.SLACK:
             log.warning(alert.message)

--- a/src/slackbot.py
+++ b/src/slackbot.py
@@ -7,7 +7,6 @@ import os
 import dotenv
 
 from dune_client.client import DuneClient
-from dune_client.interface import DuneInterface
 
 from src.query_monitor.base import QueryBase
 from src.query_monitor.factory import load_config
@@ -16,13 +15,16 @@ from src.slack_client import BasicSlackClient
 
 
 def run_slackbot(
-    query: QueryBase, dune: DuneInterface, slack_client: BasicSlackClient
+    query: QueryBase,
+    dune: DuneClient,
+    slack_client: BasicSlackClient,
+    ping_frequency: int,
 ) -> None:
     """
     This is the main method of the program.
     Instantiate a query runner, and execute its run_loop
     """
-    query_runner = QueryRunner(query, dune, slack_client)
+    query_runner = QueryRunner(query, dune, slack_client, ping_frequency)
     query_runner.run_loop()
 
 
@@ -43,4 +45,5 @@ if __name__ == "__main__":
         slack_client=BasicSlackClient(
             token=os.environ["SLACK_TOKEN"], channel=config.alert_channel
         ),
+        ping_frequency=config.ping_frequency,
     )

--- a/tests/data/ping-frequency.yaml
+++ b/tests/data/ping-frequency.yaml
@@ -1,0 +1,3 @@
+name: Ping Frequency Test
+id: 1
+ping_frequency: 28

--- a/tests/unit/test_load_config.py
+++ b/tests/unit/test_load_config.py
@@ -19,6 +19,15 @@ class TestConfigLoading(unittest.TestCase):
         config = load_config(filepath("alert-channel.yaml"))
         self.assertEqual(config.alert_channel, "Specific Channel")
 
+    def test_ping_frequency(self):
+        # Specified frequency
+        config = load_config(filepath("ping-frequency.yaml"))
+        self.assertEqual(config.ping_frequency, 28)
+
+        # Default (not specified)
+        config = load_config(filepath("counter.yaml"))
+        self.assertEqual(config.ping_frequency, 20)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
We have been experiencing issues with API rate limiting responses (e.g. "Too many requests") and it came to my attention that this project was using the "default" query ping frequency of 5 seconds. Since many of our queries are much more involved than one which would only take 5 seconds to execute, we make this configurable and also set the default here to 20 seconds (i.e. 4x the client default). This should substantially improve rate limiting issues moving forward.

