### PR TITLE
[Logging] Include results in log when alerting

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -43,7 +43,7 @@ class QueryRunner:
         results = self.dune.refresh(query.query, self.ping_frequency)
         alert = query.get_alert(results)
         if alert.level == AlertLevel.SLACK:
-            log.warning(alert.message)
+            log.warning(f"alerting with {alert.message} on result set {results}")
             self.alerter.post(alert.message)
         elif alert.level == AlertLevel.LOG:
             log.info(alert.message)


### PR DESCRIPTION
Based on [this request in slack](https://cowservices.slack.com/archives/C0361CCTFD5/p1686389636577219)

We include the result set in the warning log when alerting.

cc @nlordell 